### PR TITLE
FIX: Data centers now have a user defined label (to be identified) bu…

### DIFF
--- a/emuvim/api/zerorpcapi.py
+++ b/emuvim/api/zerorpcapi.py
@@ -28,9 +28,9 @@ class ZeroRpcApiEndpoint(object):
             self.__class__.__name__, self.ip, self.port))
 
     def connectDatacenter(self, dc):
-        self.dcs[dc.name] = dc
+        self.dcs[dc.label] = dc
         logging.info("Connected DC(%s) to API endpoint %s(%s:%d)" % (
-            dc.name, self.__class__.__name__, self.ip, self.port))
+            dc.label, self.__class__.__name__, self.ip, self.port))
 
     def start(self):
         thread = threading.Thread(target=self._api_server_thread, args=())

--- a/emuvim/dcemulator/net.py
+++ b/emuvim/dcemulator/net.py
@@ -29,17 +29,17 @@ class DCNetwork(Dockernet):
             self, controller=Controller, switch=OVSKernelSwitch, **kwargs)
         self.addController('c0')
 
-    def addDatacenter(self, name):
+    def addDatacenter(self, label):
         """
         Create and add a logical cloud data center to the network.
         """
-        if name in self.dcs:
-            raise Exception("Data center name already exists: %s" % name)
-        dc = Datacenter(name)
+        if label in self.dcs:
+            raise Exception("Data center label already exists: %s" % label)
+        dc = Datacenter(label)
         dc.net = self  # set reference to network
-        self.dcs[name] = dc
+        self.dcs[label] = dc
         dc.create()  # finally create the data center in our Mininet instance
-        logging.info("added data center: %s" % name)
+        logging.info("added data center: %s" % label)
         return dc
 
     def addLink(self, node1, node2, **params):
@@ -76,11 +76,11 @@ class DCNetwork(Dockernet):
 
         return Dockernet.addLink(self, node1, node2, **params)  # TODO we need TCLinks with user defined performance here
 
-    def addDocker( self, name, **params ):
+    def addDocker( self, label, **params ):
         """
         Wrapper for addDocker method to use custom container class.
         """
-        return Dockernet.addDocker(self, name, cls=EmulatorCompute, **params)
+        return Dockernet.addDocker(self, label, cls=EmulatorCompute, **params)
 
     def getAllContainers(self):
         """

--- a/emuvim/dcemulator/node.py
+++ b/emuvim/dcemulator/node.py
@@ -52,7 +52,7 @@ class EmulatorCompute(Docker):
         status["state"] = self.dcli.inspect_container(self.dc)["State"]
         status["id"] = self.dcli.inspect_container(self.dc)["Id"]
         status["datacenter"] = (None if self.datacenter is None
-                                else self.datacenter.name)
+                                else self.datacenter.label)
         return status
 
 
@@ -64,9 +64,15 @@ class Datacenter(object):
     Will also implement resource bookkeeping in later versions.
     """
 
-    def __init__(self, name):
+    DC_COUNTER = 1
+
+    def __init__(self, label):
         self.net = None  # DCNetwork to which we belong
-        self.name = name
+        # each node (DC) has a short internal name used by Mininet
+        # this is caused by Mininets naming limitations for swtiches etc.
+        self.name = "dc%d" % Datacenter.DC_COUNTER
+        Datacenter.DC_COUNTER += 1
+        self.label = label  # use this for user defined names
         self.switch = None  # first prototype assumes one "bigswitch" per DC
         self.containers = {}  # keep track of running containers
 

--- a/emuvim/example_topology.py
+++ b/emuvim/example_topology.py
@@ -35,10 +35,10 @@ def create_topology1():
        (each data center is one "bigswitch" in our simplified
         first prototype)
     """
-    dc1 = net.addDatacenter("dc1")
-    dc2 = net.addDatacenter("dc2")
-    dc3 = net.addDatacenter("dc3")
-    dc4 = net.addDatacenter("dc4")
+    dc1 = net.addDatacenter("datacenter1")
+    dc2 = net.addDatacenter("datacenter2")
+    dc3 = net.addDatacenter("a_very_long_data_center_name3")
+    dc4 = net.addDatacenter("datacenter4")
 
     """
     3. You can add additional SDN switches for data center
@@ -52,9 +52,9 @@ def create_topology1():
        These links can use Mininet's features to limit bw, add delay or jitter.
     """
     net.addLink(dc1, dc2)
-    net.addLink("dc1", s1)
-    net.addLink(s1, "dc3")
-    net.addLink(s1, dc4)
+    net.addLink("datacenter1", s1)
+    net.addLink(s1, dc3)
+    net.addLink(s1, "datacenter4")
 
     """
     5. We want to access and control our data centers from the outside,

--- a/emuvim/test/test_emulator.py
+++ b/emuvim/test/test_emulator.py
@@ -55,7 +55,7 @@ class simpleTestTopology( unittest.TestCase ):
                 self.net.addLink(self.s[i], self.s[i + 1])
         # add some data centers
         for i in range(0, ndatacenter):
-            self.dc.append(self.net.addDatacenter('dc%d' % i))
+            self.dc.append(self.net.addDatacenter('datacenter%d' % i))
         # add some hosts
         for i in range(0, nhosts):
             self.h.append(self.net.addHost('h%d' % i))


### PR DESCRIPTION
…t use a short internal name 'dc%d' to avoid too long host/switch names causing Mininet to crash.

This is needed if we want to generate topologies based on e.g. topology zoo files.
