### PR TITLE
fix for cross datacenter chaining.

### DIFF
--- a/src/emuvim/dcemulator/net.py
+++ b/src/emuvim/dcemulator/net.py
@@ -447,7 +447,8 @@ class DCNetwork(Containernet):
                     action = {}
                     action['type'] = 'SET_FIELD'
                     action['field'] = 'vlan_vid'
-                    action['value'] = vlan
+                    # ryu expects the field to be masked
+                    action['value'] = vlan | 0x1000
                     flow['actions'].append(action)
                 elif path.index(current_hop) == len(path) - 1:  # last node
                     match += ',dl_vlan=%s' % vlan


### PR DESCRIPTION
if ryu is used for cross datacenter chaining it will silently fail as ryu will not create a flow entry to tag flows with the correct vlan id.

ryu expects the vlan_vid field to be masked.