### PR TITLE
small fix for link params

### DIFF
--- a/src/emuvim/dcemulator/net.py
+++ b/src/emuvim/dcemulator/net.py
@@ -183,7 +183,7 @@ class DCNetwork(Containernet):
         edge_attributes = [p for p in params if p in weight_metrics]
         for attr in edge_attributes:
             # if delay: strip ms (need number as weight in graph)
-            match = re.search('([0-9]*\.?[0-9]+)', params[attr])
+            match = re.search('([0-9]*\.?[0-9]+)', str(params[attr]))
             if match:
                 attr_number = match.group(1)
             else:


### PR DESCRIPTION
not all params that can be set on a link [ bw, jitter, delay, loss] are specified as string.

Thus convert them to string before applying the regex.

This just fixes the bug of not being able to set bw or loss for a link.
The logic for setting the edge weight in the graph might still be improved.